### PR TITLE
CodeQL Branch Name

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: "CodeQL"
 on:
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '42 21 * * 0'
 


### PR DESCRIPTION
Change target branch name due to `master` -> `main` rename